### PR TITLE
Migrate to py3

### DIFF
--- a/src/example_sqlite3/__init__.py
+++ b/src/example_sqlite3/__init__.py
@@ -25,4 +25,4 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from backend import *
+from example_sqlite3.backend import *

--- a/src/optimade/__init__.py
+++ b/src/optimade/__init__.py
@@ -25,7 +25,7 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from info_endpoint import *
-from entry_endpoint import *
-from validate import *
-from process import *
+from src.optimade.info_endpoint import *
+from src.optimade.entry_endpoint import *
+from src.optimade.validate import *
+from src.optimade.process import *

--- a/src/optimade/entries.py
+++ b/src/optimade/entries.py
@@ -62,7 +62,7 @@ entry_info = {
     }
 }
 
-all_entries = entry_info.keys()
+all_entries = list(entry_info.keys())
 
 properties_by_entry = dict([(x, entry_info[x]['properties']) for x in entry_info])
 

--- a/src/translate/__init__.py
+++ b/src/translate/__init__.py
@@ -25,4 +25,4 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from optimade_filter_to_sql import *
+from src.translate.optimade_filter_to_sql import *

--- a/src/webserver/__init__.py
+++ b/src/webserver/__init__.py
@@ -25,6 +25,6 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from serve import *
-from jsonapi import *
+from src.webserver.serve import *
+from src.webserver.jsonapi import *
 

--- a/src/webserver/jsonapi.py
+++ b/src/webserver/jsonapi.py
@@ -25,7 +25,7 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from serve import WebError
+from src.webserver.serve import WebError
 
 
 def check_jsonapi_header_requirements(headers):


### PR DESCRIPTION
I am in no way endorsing this reference implementation, but I think it's important for this to be written for Python 3, as Python 2 [will not be maintained past Jan 1, 2020](https://www.python.org/dev/peps/pep-0373/). These changes are what I needed to do in order to get things running (at least the example commands in the README) using Python 3.