### PR TITLE
Add Access-Control-Allow-Origin HTTP header

### DIFF
--- a/src/webserver/serve.py
+++ b/src/webserver/serve.py
@@ -118,6 +118,7 @@ class _CallbackRequestHandler(BaseHTTPRequestHandler):
                 output = callback(request)
             self.send_response(output['response_code'])
             self.send_header('Content-type', output['content_type'])
+            self.send_header('Access-control-allow-origin', '*')
             self.end_headers()
             self.wfile_write_encoded(output['content'], output['encoding'])
 


### PR DESCRIPTION
This is required for the web-browsers' cross-domain ajax requests